### PR TITLE
compiling BigInt.cpp file

### DIFF
--- a/BigIntTest.cpp
+++ b/BigIntTest.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "BigInt.cpp"
+#include "BigInt.h"
 
 TEST(incrTest, increment)
 {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.6)
 
 project(tests)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(GTest REQUIRED)
 
-add_executable(${PROJECT_NAME} BigIntTest.cpp)
+add_executable(${PROJECT_NAME} BigInt.cpp BigIntTest.cpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE GTest::GTest)
 


### PR DESCRIPTION
`BigInt.cpp` needs to be compiled. It can be done either by including `.cpp` as it was done (not a good option), or it can be passed to compiler explicitly `add_executable(${PROJECT_NAME} BigInt.cpp BigIntTest.cpp)`